### PR TITLE
Bugout integration for Octane

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,5 @@
+import octane
+
+octane.api_key = "lol"
+
+print(octane.Customer.list())

--- a/octane/__init__.py
+++ b/octane/__init__.py
@@ -15,11 +15,45 @@ verify_ssl_certs = True
 proxy = None
 default_http_client = None
 app_info = None
-enable_telemetry = True
 max_network_retries = 0
 ca_bundle_path = os.path.join(
     os.path.dirname(__file__), "data", "ca-certificates.crt"
 )
+
+# Octane reporting configuration
+octane_tags = []
+session_id = ""
+consent = None
+reporter = None
+try:
+    import uuid
+
+    from humbug.consent import HumbugConsent, environment_variable_opt_out, no
+    from humbug.report import HumbugReporter
+
+    from octane.version import VERSION
+
+    octane_tags = ["version:{}".format(VERSION)]
+
+    session_id = str(uuid.uuid4())
+
+    reporter_token = "8fffe9ff-a402-4f8b-a3b3-c7706ba935fc"
+
+    consent = HumbugConsent(environment_variable_opt_out("OCTANE_REPORTING_ENABLED", no))
+    reporter = HumbugReporter(
+        "octane",
+        consent,
+        client_id=client_id,
+        session_id=session_id,
+        bugout_token=reporter_token
+    )
+
+    reporter.system_report(tags=octane_tags)
+    reporter.setup_excepthook(tags=octane_tags)
+except:
+    pass
+
+enable_telemetry = True if consent is None else consent.check()
 
 # Set to either 'debug' or 'info', controls console logging
 log = None

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     package_data={"octane": ["data/ca-certificates.crt"]},
     zip_safe=False,
     install_requires=[
+        'humbug; python_version >= "3.5"',
         'requests >= 2.20; python_version >= "3.0"',
         'requests[security] >= 2.20; python_version < "3.0"',
     ],


### PR DESCRIPTION
@akshalaby : This PR introduces usage and crash reporting for Octane using Bugout.

Library users can opt out of this reporting by setting the environment variable `OCTANE_REPORTING_ENABLED=no`.

You can manage this integration at https://bugout.dev/account/teams

Happy to make changes as desired (e.g. we can remove `demo.py`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getoctane/octane-python/1)
<!-- Reviewable:end -->
